### PR TITLE
WIP: Add support for kafka producer config linger.ms in kafka sink

### DIFF
--- a/dagger-core/src/main/java/io/odpf/dagger/core/sink/SinkOrchestrator.java
+++ b/dagger-core/src/main/java/io/odpf/dagger/core/sink/SinkOrchestrator.java
@@ -107,6 +107,9 @@ public class SinkOrchestrator implements TelemetryPublisher {
             kafkaProducerConfigs.setProperty(SINK_KAFKA_COMPRESSION_TYPE_KEY, SINK_KAFKA_COMPRESSION_TYPE_DEFAULT);
             kafkaProducerConfigs.setProperty(SINK_KAFKA_MAX_REQUEST_SIZE_KEY, SINK_KAFKA_MAX_REQUEST_SIZE_DEFAULT);
         }
+        String lingerMs = configuration.getString(SINK_KAFKA_LINGER_MS_KEY, SINK_KAFKA_LINGER_MS_DEFAULT);
+        kafkaProducerConfigs.setProperty(SINK_KAFKA_LINGER_MS_CONFIG_KEY, lingerMs);
+
         return kafkaProducerConfigs;
     }
 

--- a/dagger-core/src/main/java/io/odpf/dagger/core/utils/Constants.java
+++ b/dagger-core/src/main/java/io/odpf/dagger/core/utils/Constants.java
@@ -74,11 +74,14 @@ public class Constants {
     public static final String SINK_KAFKA_JSON_SCHEMA_KEY = "SINK_KAFKA_JSON_SCHEMA";
     public static final String SINK_KAFKA_DATA_TYPE = "SINK_KAFKA_DATA_TYPE";
     public static final String SINK_KAFKA_PRODUCE_LARGE_MESSAGE_ENABLE_KEY = "SINK_KAFKA_PRODUCE_LARGE_MESSAGE_ENABLE";
+    public static final String SINK_KAFKA_LINGER_MS_KEY = "SINK_KAFKA_LINGER_MS";
     public static final boolean SINK_KAFKA_PRODUCE_LARGE_MESSAGE_ENABLE_DEFAULT = false;
     public static final String SINK_KAFKA_COMPRESSION_TYPE_KEY = "compression.type";
+    public static final String SINK_KAFKA_LINGER_MS_CONFIG_KEY = "linger.ms";
     public static final String SINK_KAFKA_COMPRESSION_TYPE_DEFAULT = "snappy";
     public static final String SINK_KAFKA_MAX_REQUEST_SIZE_KEY = "max.request.size";
     public static final String SINK_KAFKA_MAX_REQUEST_SIZE_DEFAULT = "20971520";
+    public static final String SINK_KAFKA_LINGER_MS_DEFAULT = "5";
 
     public static final String ES_TYPE = "ES";
     public static final String HTTP_TYPE = "HTTP";

--- a/dagger-core/src/main/java/io/odpf/dagger/core/utils/Constants.java
+++ b/dagger-core/src/main/java/io/odpf/dagger/core/utils/Constants.java
@@ -81,7 +81,7 @@ public class Constants {
     public static final String SINK_KAFKA_COMPRESSION_TYPE_DEFAULT = "snappy";
     public static final String SINK_KAFKA_MAX_REQUEST_SIZE_KEY = "max.request.size";
     public static final String SINK_KAFKA_MAX_REQUEST_SIZE_DEFAULT = "20971520";
-    public static final String SINK_KAFKA_LINGER_MS_DEFAULT = "5";
+    public static final String SINK_KAFKA_LINGER_MS_DEFAULT = "0";
 
     public static final String ES_TYPE = "ES";
     public static final String HTTP_TYPE = "HTTP";


### PR DESCRIPTION
[linger.ms](https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#linger-ms) defines the maximum interval for buffering messages in the client before being produced to kafka. This improves efficiency of the producer and also greatly reduces the load on kafka.

The interval and buffering also ensures better compression when enabled.

More Reading: https://github.com/confluentinc/librdkafka/blob/master/INTRODUCTION.md#performance

Open Questions:
- Other configuration related to kafka sink are similar to flags, would you want this configuration be also similar to switch where the recommended config(1000) is behind a flag and in the code or should it be similar to the min_commit interval config we have for firehose.

Todo:
- Add documentation for the config exposed[Waitiing on finalisation for config exposure pattern]
- Update version