### PR TITLE
fix:[longbow] excluded module google-cloud-bigtable from minimaljar

### DIFF
--- a/dagger-core/build.gradle
+++ b/dagger-core/build.gradle
@@ -65,7 +65,7 @@ dependencies {
         exclude group: 'org.apache.httpcomponents'
         exclude group: 'com.google.protobuf'
         exclude group: 'com.datadoghq'
-        exclude group: 'com.google.cloud.bigtable'
+        exclude group: 'com.google.cloud', module:'google-cloud-bigtable'
     }
     compileOnly 'org.projectlombok:lombok:1.18.8'
     annotationProcessor 'org.projectlombok:lombok:1.18.8'


### PR DESCRIPTION
Currently, longbow daggers are broken, and throwing  -
```
2023-04-19 14:27:34,786 INFO  com.google.cloud.bigtable.grpc.BigtableSession               - Opening session for projectId gopay-dsxxxxxx, instanceId risk-serxxxxxxxx, on data host bigtable.googleapis.com, admin host bigtableadmin.googleapis.com.
2023-04-19 14:27:34,789 INFO  com.google.cloud.bigtable.grpc.BigtableSession               - Bigtable options: BigtableOptions{dataHost=bigtable.googleapis.com, adminHost=bigtableadmin.googleapis.com, port=443, projectId=gopay-dsxxxxxxx, instanceId=riskxxxxxxxxx, appProfileId=, userAgent=hbase-2.1.3, credentialType=DefaultCredentials, dataChannelCount=4, retryOptions=RetryOptions{retriesEnabled=true, allowRetriesWithoutTimestamp=false, statusToRetryOn=[UNAVAILABLE, DEADLINE_EXCEEDED, ABORTED, UNAUTHENTICATED], initialBackoffMillis=5, maxElapsedBackoffMillis=60000, backoffMultiplier=1.5, streamingBufferSize=60, readPartialRowTimeoutMillis=60000, maxScanTimeoutRetries=3}, bulkOptions=BulkOptions{asyncMutatorCount=2, useBulkApi=true, bulkMaxKeyCount=125, bulkMaxRequestSize=1048576, autoflushMs=0, maxInflightRpcs=40, maxMemory=168670003, enableBulkMutationThrottling=false, bulkMutationRpcTargetMs=100}, callOptionsConfig=CallOptionsConfig{useTimeout=false, shortRpcTimeoutMs=60000, longRpcTimeoutMs=600000}, usePlaintextNegotiation=false, useCachedDataPool=false, useBatch=false, useGCJClient=false}.
2023-04-19 14:27:34,880 INFO  com.google.cloud.bigtable.grpc.BigtableSession               - Creating new channel for bigtable.googleapis.com
2023-04-19 14:27:35,266 INFO  com.google.cloud.bigtable.grpc.BigtableSession               - Creating new channel for bigtable.googleapis.com
2023-04-19 14:27:35,269 INFO  com.google.cloud.bigtable.grpc.BigtableSession               - Creating new channel for bigtable.googleapis.com
2023-04-19 14:27:35,271 INFO  com.google.cloud.bigtable.grpc.BigtableSession               - Creating new channel for bigtable.googleapis.com
2023-04-19 14:27:35,736 ERROR org.apache.flink.runtime.util.ClusterUncaughtExceptionHandler - WARNING: Thread 'grpc-default-executor-0' produced an uncaught exception. If you want to fail on uncaught exceptions, then configure cluster.uncaught-exception-handling accordingly
java.lang.NoSuchMethodError: com.google.protobuf.GeneratedMessageV3.isStringEmpty(Ljava/lang/Object;)Z
	at com.google.bigtable.admin.v2.GetTableRequest.getSerializedSize(GetTableRequest.java:249) ~[blob_p-792f51a43d7eb14eef4d7f484350c1f0cbc62fe1-b5dcb833e2e5ea87b518e34e11c2fb7f:?]
	at io.grpc.protobuf.lite.ProtoInputStream.available(ProtoInputStream.java:108) ~[blob_p-792f51a43d7eb14eef4d7f484350c1f0cbc62fe1-b5dcb833e2e5ea87b518e34e11c2fb7f:?]
	at io.grpc.internal.MessageFramer.getKnownLength(MessageFramer.java:205) ~[blob_p-792f51a43d7eb14eef4d7f484350c1f0cbc62fe1-b5dcb833e2e5ea87b518e34e11c2fb7f:?]
	at io.grpc.internal.MessageFramer.writePayload(MessageFramer.java:137) ~[blob_p-792f51a43d7eb14eef4d7f484350c1f0cbc62fe1-b5dcb833e2e5ea87b518e34e11c2fb7f:?]
	at io.grpc.internal.AbstractStream.writeMessage(AbstractStream.java:65) ~[blob_p-792f51a43d7eb14eef4d7f484350c1f0cbc62fe1-b5dcb833e2e5ea87b518e34e11c2fb7f:?]
	at io.grpc.internal.ForwardingClientStream.writeMessage(ForwardingClientStream.java:37) ~[blob_p-792f51a43d7eb14eef4d7f484350c1f0cbc62fe1-b5dcb833e2e5ea87b518e34e11c2fb7f:?]
	at io.grpc.internal.DelayedStream$6.run(DelayedStream.java:282) ~[blob_p-792f51a43d7eb14eef4d7f484350c1f0cbc62fe1-b5dcb833e2e5ea87b518e34e11c2fb7f:?]
	at io.grpc.internal.DelayedStream.drainPendingCalls(DelayedStream.java:181) ~[blob_p-792f51a43d7eb14eef4d7f484350c1f0cbc62fe1-b5dcb833e2e5ea87b518e34e11c2fb7f:?]
	at io.grpc.internal.DelayedStream.access$100(DelayedStream.java:43) ~[blob_p-792f51a43d7eb14eef4d7f484350c1f0cbc62fe1-b5dcb833e2e5ea87b518e34e11c2fb7f:?]
	at io.grpc.internal.DelayedStream$4.run(DelayedStream.java:147) ~[blob_p-792f51a43d7eb14eef4d7f484350c1f0cbc62fe1-b5dcb833e2e5ea87b518e34e11c2fb7f:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_322]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_322]
	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_322]
2023-04-19 14:27:35,772 INFO  com.gotocompany.stencil.DescriptorMapBuilder                 - successfully fetched http://stencil.gtfdata.io/v1beta1/namespaces/gojek/schemas/esb-log-entities/versions/752

```