### PR TITLE
feat: adding configuration to provide exclusion for failOnError with http post processor

### DIFF
--- a/dagger-core/src/main/java/com/gotocompany/dagger/core/processors/external/http/HttpAsyncConnector.java
+++ b/dagger-core/src/main/java/com/gotocompany/dagger/core/processors/external/http/HttpAsyncConnector.java
@@ -12,6 +12,7 @@ import com.gotocompany.dagger.core.utils.Constants;
 import com.gotocompany.dagger.common.metrics.managers.MeterStatsManager;
 import com.gotocompany.dagger.core.processors.external.AsyncConnector;
 import com.gotocompany.dagger.core.processors.external.ExternalMetricConfig;
+import io.netty.util.internal.StringUtil;
 import org.apache.flink.streaming.api.functions.async.ResultFuture;
 import org.apache.flink.types.Row;
 
@@ -19,6 +20,13 @@ import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.BoundRequestBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.asynchttpclient.Dsl.asyncHttpClient;
 import static org.asynchttpclient.Dsl.config;
@@ -31,6 +39,7 @@ public class HttpAsyncConnector extends AsyncConnector {
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpAsyncConnector.class.getName());
     private AsyncHttpClient httpClient;
     private HttpSourceConfig httpSourceConfig;
+    private Set<Integer> failOnErrorsExclusionSet;
 
     /**
      * Instantiates a new Http async connector with specified http client.
@@ -104,7 +113,7 @@ public class HttpAsyncConnector extends AsyncConnector {
             }
 
             BoundRequestBuilder request = HttpRequestFactory.createRequest(httpSourceConfig, httpClient, requestVariablesValues, dynamicHeaderVariablesValues, endpointVariablesValues);
-            HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, getMeterStatsManager(),
+            HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, getFailOnErrorsExclusionSet(httpSourceConfig.getExcludeFailOnErrorsCodeRange()), getMeterStatsManager(),
                     rowManager, getColumnNameManager(), getOutputDescriptor(resultFuture), resultFuture, getErrorReporter(), new PostResponseTelemetry());
             httpResponseHandler.startTimer();
             request.execute(httpResponseHandler);
@@ -113,5 +122,20 @@ public class HttpAsyncConnector extends AsyncConnector {
             resultFuture.completeExceptionally(e);
         }
 
+    }
+
+    protected Set<Integer> getFailOnErrorsExclusionSet(String excludeFailOnErrorsCodeRange) {
+        if (failOnErrorsExclusionSet == null) {
+            failOnErrorsExclusionSet = new HashSet<Integer>();
+            if (StringUtil.isNullOrEmpty(excludeFailOnErrorsCodeRange)) {
+                return failOnErrorsExclusionSet;
+            }
+            String[] ranges = excludeFailOnErrorsCodeRange.split(",");
+            Arrays.stream(ranges).forEach(range -> {
+                List<Integer> rangeList = Arrays.stream(range.split("-")).map(Integer::parseInt).collect(Collectors.toList());
+                IntStream.rangeClosed(rangeList.get(0), rangeList.get(rangeList.size() - 1)).forEach(statusCode -> failOnErrorsExclusionSet.add(statusCode));
+            });
+        }
+        return failOnErrorsExclusionSet;
     }
 }

--- a/dagger-core/src/main/java/com/gotocompany/dagger/core/processors/external/http/HttpResponseHandler.java
+++ b/dagger-core/src/main/java/com/gotocompany/dagger/core/processors/external/http/HttpResponseHandler.java
@@ -99,6 +99,7 @@ public class HttpResponseHandler extends AsyncCompletionHandler<Object> {
 
     @Override
     public void onThrowable(Throwable t) {
+        t.printStackTrace();
         meterStatsManager.markEvent(ExternalSourceAspects.OTHER_ERRORS);
         failureHandler(t.getMessage(), httpSourceConfig.isFailOnErrors());
     }
@@ -147,10 +148,10 @@ public class HttpResponseHandler extends AsyncCompletionHandler<Object> {
         if (statusCode == 0 || StringUtil.isNullOrEmpty(httpSourceConfig.getExcludeFailOnErrorsCodeRange())) {
             return true;
         }
-        return !getFailOnErrorCodeRanges(httpSourceConfig.getExcludeFailOnErrorsCodeRange()).contains(statusCode);
+        return !getExcludeFailOnErrorCodes(httpSourceConfig.getExcludeFailOnErrorsCodeRange()).contains(statusCode);
     }
 
-    private HashSet<Integer> getFailOnErrorCodeRanges(String input) {
+    private HashSet<Integer> getExcludeFailOnErrorCodes(String input) {
         String[] ranges = input.split(",");
         HashSet<Integer> statusSet = new HashSet<Integer>();
         Arrays.stream(ranges).forEach(range -> {

--- a/dagger-core/src/main/java/com/gotocompany/dagger/core/processors/external/http/HttpSourceConfig.java
+++ b/dagger-core/src/main/java/com/gotocompany/dagger/core/processors/external/http/HttpSourceConfig.java
@@ -26,6 +26,7 @@ public class HttpSourceConfig implements Serializable, SourceConfig {
     private String streamTimeout;
     private String connectTimeout;
     private boolean failOnErrors;
+    private String excludeFailOnErrorsCodeRange;
     @SerializedName(value = "type", alternate = {"Type", "TYPE"})
     private String type;
     private String capacity;
@@ -49,6 +50,7 @@ public class HttpSourceConfig implements Serializable, SourceConfig {
      * @param streamTimeout      the stream timeout
      * @param connectTimeout     the connect timeout
      * @param failOnErrors       the fail on errors
+     * @param excludeFailOnErrorsCodeRange the exclude fail on errors code range
      * @param type               the type
      * @param capacity           the capacity
      * @param headers            the static headers
@@ -56,7 +58,7 @@ public class HttpSourceConfig implements Serializable, SourceConfig {
      * @param metricId           the metric id
      * @param retainResponseType the retain response type
      */
-    public HttpSourceConfig(String endpoint, String endpointVariables, String verb, String requestPattern, String requestVariables, String headerPattern, String headerVariables, String streamTimeout, String connectTimeout, boolean failOnErrors, String type, String capacity, Map<String, String> headers, Map<String, OutputMapping> outputMapping, String metricId, boolean retainResponseType) {
+    public HttpSourceConfig(String endpoint, String endpointVariables, String verb, String requestPattern, String requestVariables, String headerPattern, String headerVariables, String streamTimeout, String connectTimeout, boolean failOnErrors, String excludeFailOnErrorsCodeRange,  String type, String capacity, Map<String, String> headers, Map<String, OutputMapping> outputMapping, String metricId, boolean retainResponseType) {
         this.endpoint = endpoint;
         this.endpointVariables = endpointVariables;
         this.verb = verb;
@@ -67,6 +69,7 @@ public class HttpSourceConfig implements Serializable, SourceConfig {
         this.streamTimeout = streamTimeout;
         this.connectTimeout = connectTimeout;
         this.failOnErrors = failOnErrors;
+        this.excludeFailOnErrorsCodeRange = excludeFailOnErrorsCodeRange;
         this.type = type;
         this.capacity = capacity;
         this.headers = headers;
@@ -162,6 +165,16 @@ public class HttpSourceConfig implements Serializable, SourceConfig {
         return failOnErrors;
     }
 
+    /**
+     * Gets failOnErrorsCodeRange Variable.
+     *
+     * @return the failOnErrorsCodeRange Variable
+     */
+    public String getExcludeFailOnErrorsCodeRange() {
+        return excludeFailOnErrorsCodeRange;
+    }
+
+
     @Override
     public String getMetricId() {
         return metricId;
@@ -245,11 +258,11 @@ public class HttpSourceConfig implements Serializable, SourceConfig {
             return false;
         }
         HttpSourceConfig that = (HttpSourceConfig) o;
-        return failOnErrors == that.failOnErrors && retainResponseType == that.retainResponseType && Objects.equals(endpoint, that.endpoint) && Objects.equals(verb, that.verb) && Objects.equals(requestPattern, that.requestPattern) && Objects.equals(requestVariables, that.requestVariables) && Objects.equals(headerPattern, that.headerPattern) && Objects.equals(headerVariables, that.headerVariables) && Objects.equals(streamTimeout, that.streamTimeout) && Objects.equals(connectTimeout, that.connectTimeout) && Objects.equals(type, that.type) && Objects.equals(capacity, that.capacity) && Objects.equals(headers, that.headers) && Objects.equals(outputMapping, that.outputMapping) && Objects.equals(metricId, that.metricId);
+        return failOnErrors == that.failOnErrors && excludeFailOnErrorsCodeRange == that.excludeFailOnErrorsCodeRange && retainResponseType == that.retainResponseType && Objects.equals(endpoint, that.endpoint) && Objects.equals(verb, that.verb) && Objects.equals(requestPattern, that.requestPattern) && Objects.equals(requestVariables, that.requestVariables) && Objects.equals(headerPattern, that.headerPattern) && Objects.equals(headerVariables, that.headerVariables) && Objects.equals(streamTimeout, that.streamTimeout) && Objects.equals(connectTimeout, that.connectTimeout) && Objects.equals(type, that.type) && Objects.equals(capacity, that.capacity) && Objects.equals(headers, that.headers) && Objects.equals(outputMapping, that.outputMapping) && Objects.equals(metricId, that.metricId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(endpoint, endpointVariables, verb, requestPattern, requestVariables, headerPattern, headerVariables, streamTimeout, connectTimeout, failOnErrors, type, capacity, headers, outputMapping, metricId, retainResponseType);
+        return Objects.hash(endpoint, endpointVariables, verb, requestPattern, requestVariables, headerPattern, headerVariables, streamTimeout, connectTimeout, failOnErrors, excludeFailOnErrorsCodeRange, type, capacity, headers, outputMapping, metricId, retainResponseType);
     }
 }

--- a/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/PostProcessorConfigTest.java
+++ b/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/PostProcessorConfigTest.java
@@ -64,7 +64,7 @@ public class PostProcessorConfigTest {
         outputMapping = new OutputMapping("$.data.tensor.values[0]");
         outputMappings.put("surge_factor", outputMapping);
 
-        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("http://localhost:8000", "", "post", null, null, null, null, "5000", "5000", true, null, null, headerMap, outputMappings, null, false);
+        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("http://localhost:8000", "", "post", null, null, null, null, "5000", "5000", true, null, null, null, headerMap, outputMappings, null, false);
 
         assertEquals(httpSourceConfig, defaultPostProcessorConfig.getExternalSource().getHttpConfig().get(0));
     }
@@ -120,7 +120,7 @@ public class PostProcessorConfigTest {
     @Test
     public void shouldNotBeEmptyWhenExternalSourceHasHttpConfigExist() {
         ArrayList<HttpSourceConfig> http = new ArrayList<>();
-        http.add(new HttpSourceConfig("", "", "", "", "", "", "", "", "", false, "", "", new HashMap<>(), new HashMap<>(), "metricId_01", false));
+        http.add(new HttpSourceConfig("", "", "", "", "", "", "", "", "", false, null, "", "", new HashMap<>(), new HashMap<>(), "metricId_01", false));
         ArrayList<EsSourceConfig> es = new ArrayList<>();
         ArrayList<PgSourceConfig> pg = new ArrayList<>();
         ExternalSourceConfig externalSourceConfig = new ExternalSourceConfig(http, es, pg, new ArrayList<>());

--- a/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/ExternalPostProcessorTest.java
+++ b/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/ExternalPostProcessorTest.java
@@ -69,7 +69,7 @@ public class ExternalPostProcessorTest {
         HashMap<String, OutputMapping> httpColumnNames = new HashMap<>();
         httpColumnNames.put("http_field_1", new OutputMapping(""));
         httpColumnNames.put("http_field_2", new OutputMapping(""));
-        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("endpoint", "", "POST", "/some/patttern/%s", "variable", "", "", "123", "234", false, "type", "20", new HashMap<>(), httpColumnNames, "metricId_01", false);
+        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("endpoint", "", "POST", "/some/patttern/%s", "variable", "", "", "123", "234", false, null, "type", "20", new HashMap<>(), httpColumnNames, "metricId_01", false);
         HashMap<String, OutputMapping> esOutputMapping = new HashMap<>();
         esOutputMapping.put("es_field_1", new OutputMapping(""));
         EsSourceConfig esSourceConfig = new EsSourceConfig("host", "port", "", "", "endpointPattern",
@@ -132,7 +132,7 @@ public class ExternalPostProcessorTest {
         outputMapping.put("order_id", new OutputMapping("path"));
 
         List<HttpSourceConfig> httpSourceConfigs = new ArrayList<>();
-        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("endpoint", "", "POST", "/some/patttern/%s", "variable", "", "", "123", "234", false, "type", "20", new HashMap<>(), outputMapping, "metricId_01", false);
+        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("endpoint", "", "POST", "/some/patttern/%s", "variable", "", "", "123", "234", false, null, "type", "20", new HashMap<>(), outputMapping, "metricId_01", false);
         httpSourceConfigs.add(httpSourceConfig);
 
         List<EsSourceConfig> esSourceConfigs = new ArrayList<>();

--- a/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/ExternalSourceConfigTest.java
+++ b/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/ExternalSourceConfigTest.java
@@ -29,7 +29,7 @@ public class ExternalSourceConfigTest {
         HashMap<String, OutputMapping> httpOutputMapping = new HashMap<>();
         httpOutputMapping.put("http_field_1", new OutputMapping(""));
         httpOutputMapping.put("http_field_2", new OutputMapping(""));
-        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("endpoint", "", "POST", "/some/patttern/%s", "variable", "", "", "123", "234", false, "type", "20", new HashMap<>(), httpOutputMapping, "metricId_01", false);
+        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("endpoint", "", "POST", "/some/patttern/%s", "variable", "", "", "123", "234", false, null, "type", "20", new HashMap<>(), httpOutputMapping, "metricId_01", false);
         http = new ArrayList<>();
         http.add(httpSourceConfig);
         es = new ArrayList<>();

--- a/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/grpc/GrpcSourceConfigTest.java
+++ b/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/grpc/GrpcSourceConfigTest.java
@@ -119,13 +119,13 @@ public class GrpcSourceConfigTest {
 
     @Test
     public void hasTypeShouldBeFalseWhenTypeIsNull() {
-        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("", "", "", "", "", "", "", null, "", false, null, "", new HashMap<>(), new HashMap<>(), metricId, false);
+        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("", "", "", "", "", "", "", null, "", false, "", null, "", new HashMap<>(), new HashMap<>(), metricId, false);
         assertFalse(httpSourceConfig.hasType());
     }
 
     @Test
     public void hasTypeShouldBeFalseWhenTypeIsEmpty() {
-        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("", "",  "", "", "", "", "", "", "", false, "", "", new HashMap<>(), new HashMap<>(), metricId, false);
+        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("", "",  "", "", "", "", "", "", "", false, "", "", "", new HashMap<>(), new HashMap<>(), metricId, false);
         assertFalse(httpSourceConfig.hasType());
     }
 

--- a/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/http/HttpAsyncConnectorTest.java
+++ b/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/http/HttpAsyncConnectorTest.java
@@ -96,7 +96,7 @@ public class HttpAsyncConnectorTest {
         externalMetricConfig = new ExternalMetricConfig("metricId-http-01", shutDownPeriod, telemetryEnabled);
 
         defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}",
-                "customer_id", "", "", "123", "234", false, httpConfigType, "345",
+                "customer_id", "", "", "123", "234", false, null, httpConfigType, "345",
                 headers, outputMapping, "metricId_02", false);
     }
 
@@ -186,7 +186,7 @@ public class HttpAsyncConnectorTest {
     public void shouldCompleteExceptionallyWhenRequestVariableIsInvalid() throws Exception {
         when(defaultDescriptorManager.getDescriptor(inputProtoClasses[0])).thenReturn(TestBookingLogMessage.getDescriptor());
         String invalidRequestVariable = "invalid_variable";
-        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", invalidRequestVariable, "", "", "123", "234", false, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
+        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", invalidRequestVariable, "", "", "123", "234", false, null, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
         when(httpClient.preparePost("http://localhost:8080/test")).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody("{\"key\": \"123456\"}")).thenReturn(boundRequestBuilder);
         HttpAsyncConnector httpAsyncConnector = new HttpAsyncConnector(defaultHttpSourceConfig, externalMetricConfig, schemaConfig, httpClient, errorReporter, meterStatsManager, defaultDescriptorManager);
@@ -209,7 +209,7 @@ public class HttpAsyncConnectorTest {
     @Test
     public void shouldCompleteExceptionallyWhenEndpointVariableIsEmptyAndRequiredInPattern() throws Exception {
         String emptyRequestVariable = "";
-        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", emptyRequestVariable, "", "", "123", "234", false, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
+        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", emptyRequestVariable, "", "", "123", "234", false, null, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
         when(defaultDescriptorManager.getDescriptor(inputProtoClasses[0])).thenReturn(TestBookingLogMessage.getDescriptor());
         when(httpClient.preparePost("http://localhost:8080/test")).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody("{\"key\": \"123456\"}")).thenReturn(boundRequestBuilder);
@@ -226,7 +226,7 @@ public class HttpAsyncConnectorTest {
     @Test
     public void shouldEnrichWhenEndpointVariableIsEmptyAndNotRequiredInPattern() throws Exception {
         String emptyRequestVariable = "";
-        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"static\"}", emptyRequestVariable, "", "", "123", "234", false, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
+        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"static\"}", emptyRequestVariable, "", "", "123", "234", false, null, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
         HttpAsyncConnector httpAsyncConnector = new HttpAsyncConnector(defaultHttpSourceConfig, externalMetricConfig, schemaConfig, httpClient, errorReporter, meterStatsManager, defaultDescriptorManager);
 
         when(httpClient.preparePost("http://localhost:8080/test")).thenReturn(boundRequestBuilder);
@@ -246,7 +246,7 @@ public class HttpAsyncConnectorTest {
     @Test
     public void shouldCompleteExceptionallyWhenEndpointPatternIsInvalid() throws Exception {
         String invalidRequestPattern = "{\"key\": \"%\"}";
-        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", invalidRequestPattern, "customer_id", "", "", "123", "234", false, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
+        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", invalidRequestPattern, "customer_id", "", "", "123", "234", false, null, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
         when(defaultDescriptorManager.getDescriptor(inputProtoClasses[0])).thenReturn(TestBookingLogMessage.getDescriptor());
         when(httpClient.preparePost("http://localhost:8080/test")).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody("{\"key\": \"123456\"}")).thenReturn(boundRequestBuilder);
@@ -261,7 +261,7 @@ public class HttpAsyncConnectorTest {
 
     @Test
     public void shouldGetDescriptorFromOutputProtoIfTypeNotGiven() throws Exception {
-        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", false, null, "345", headers, outputMapping, "metricId_02", false);
+        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", false, null, null, "345", headers, outputMapping, "metricId_02", false);
         when(httpClient.preparePost("http://localhost:8080/test")).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody("{\"key\": \"123456\"}")).thenReturn(boundRequestBuilder);
         when(stencilClientOrchestrator.getStencilClient()).thenReturn(stencilClient);
@@ -276,7 +276,7 @@ public class HttpAsyncConnectorTest {
 
     @Test
     public void shouldGetDescriptorFromTypeIfGiven() throws Exception {
-        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", false, "TestBookingLogMessage", "345", headers, outputMapping, "metricId_02", false);
+        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", false, null, "TestBookingLogMessage", "345", headers, outputMapping, "metricId_02", false);
         when(httpClient.preparePost("http://localhost:8080/test")).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody("{\"key\": \"123456\"}")).thenReturn(boundRequestBuilder);
         when(stencilClientOrchestrator.getStencilClient()).thenReturn(stencilClient);
@@ -292,7 +292,7 @@ public class HttpAsyncConnectorTest {
     @Test
     public void shouldCompleteExceptionallyWhenEndpointPatternIsIncompatible() throws Exception {
         String invalidRequestPattern = "{\"key\": \"%d\"}";
-        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", invalidRequestPattern, "customer_id", "", "", "123", "234", false, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
+        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", invalidRequestPattern, "customer_id", "", "", "123", "234", false, null, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
         when(defaultDescriptorManager.getDescriptor(inputProtoClasses[0])).thenReturn(TestBookingLogMessage.getDescriptor());
         when(httpClient.preparePost("http://localhost:8080/test")).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody("{\"key\": \"123456\"}")).thenReturn(boundRequestBuilder);
@@ -343,7 +343,7 @@ public class HttpAsyncConnectorTest {
         when(stencilClientOrchestrator.getStencilClient()).thenReturn(stencilClient);
         when(defaultDescriptorManager.getDescriptor(inputProtoClasses[0])).thenReturn(TestBookingLogMessage.getDescriptor());
         HttpSourceConfig dynamicHeaderHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}",
-                "customer_id", "{\"X_KEY\": \"%s\"}", "customer_id", "123", "234", false, httpConfigType, "345",
+                "customer_id", "{\"X_KEY\": \"%s\"}", "customer_id", "123", "234", false, null, httpConfigType, "345",
                 headers, outputMapping, "metricId_02", false);
         HttpAsyncConnector httpAsyncConnector = new HttpAsyncConnector(dynamicHeaderHttpSourceConfig, externalMetricConfig, schemaConfig, httpClient, errorReporter, meterStatsManager, defaultDescriptorManager);
 
@@ -361,7 +361,7 @@ public class HttpAsyncConnectorTest {
         when(stencilClientOrchestrator.getStencilClient()).thenReturn(stencilClient);
         when(defaultDescriptorManager.getDescriptor(inputProtoClasses[0])).thenReturn(TestBookingLogMessage.getDescriptor());
         HttpSourceConfig dynamicHeaderHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}",
-                "customer_id", "{\"X_KEY\": \"%s\"}", "customer_ids", "123", "234", false, httpConfigType, "345",
+                "customer_id", "{\"X_KEY\": \"%s\"}", "customer_ids", "123", "234", false, null, httpConfigType, "345",
                 headers, outputMapping, "metricId_02", false);
         HttpAsyncConnector httpAsyncConnector = new HttpAsyncConnector(dynamicHeaderHttpSourceConfig, externalMetricConfig, schemaConfig, httpClient, errorReporter, meterStatsManager, defaultDescriptorManager);
         httpAsyncConnector.open(flinkConfiguration);
@@ -376,7 +376,7 @@ public class HttpAsyncConnectorTest {
     public void shouldCompleteExceptionallyWhenHeaderVariableIsInvalid() throws Exception {
         when(defaultDescriptorManager.getDescriptor(inputProtoClasses[0])).thenReturn(TestBookingLogMessage.getDescriptor());
         String invalidHeaderVariable = "invalid_variable";
-        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "{\"key\": \"%s\"}", invalidHeaderVariable, "123", "234", false, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
+        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "{\"key\": \"%s\"}", invalidHeaderVariable, "123", "234", false, null, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
         when(httpClient.preparePost("http://localhost:8080/test")).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody("{\"key\": \"123456\"}")).thenReturn(boundRequestBuilder);
         HttpAsyncConnector httpAsyncConnector = new HttpAsyncConnector(defaultHttpSourceConfig, externalMetricConfig, schemaConfig, httpClient, errorReporter, meterStatsManager, defaultDescriptorManager);
@@ -399,7 +399,7 @@ public class HttpAsyncConnectorTest {
     @Test
     public void shouldCompleteExceptionallyWhenHeaderPatternIsIncompatible() throws Exception {
         String invalidHeaderPattern = "{\"key\": \"%d\"}";
-        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", invalidHeaderPattern, "customer_id", "123", "234", false, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
+        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", invalidHeaderPattern, "customer_id", "123", "234", false, null, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
         when(defaultDescriptorManager.getDescriptor(inputProtoClasses[0])).thenReturn(TestBookingLogMessage.getDescriptor());
         when(httpClient.preparePost("http://localhost:8080/test")).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody("{\"key\": \"123456\"}")).thenReturn(boundRequestBuilder);
@@ -414,7 +414,17 @@ public class HttpAsyncConnectorTest {
 
     @Test
     public void shouldThrowExceptionInTimeoutIfFailOnErrorIsTrue() throws Exception {
-        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
+        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, null, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
+        HttpAsyncConnector httpAsyncConnector = new HttpAsyncConnector(httpSourceConfig, externalMetricConfig, schemaConfig, httpClient, errorReporter, meterStatsManager, defaultDescriptorManager);
+
+        httpAsyncConnector.timeout(streamData, resultFuture);
+
+        verify(resultFuture, times(1)).completeExceptionally(any(TimeoutException.class));
+    }
+
+    @Test
+    public void shouldThrowExceptionInTimeoutIfFailOnErrorIsTrueWithFailOnErrorCodeRange() throws Exception {
+        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, "400-600", httpConfigType, "345", headers, outputMapping, "metricId_02", false);
         HttpAsyncConnector httpAsyncConnector = new HttpAsyncConnector(httpSourceConfig, externalMetricConfig, schemaConfig, httpClient, errorReporter, meterStatsManager, defaultDescriptorManager);
 
         httpAsyncConnector.timeout(streamData, resultFuture);
@@ -424,7 +434,17 @@ public class HttpAsyncConnectorTest {
 
     @Test
     public void shouldReportFatalInTimeoutIfFailOnErrorIsTrue() throws Exception {
-        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
+        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, null, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
+        HttpAsyncConnector httpAsyncConnector = new HttpAsyncConnector(httpSourceConfig, externalMetricConfig, schemaConfig, httpClient, errorReporter, meterStatsManager, defaultDescriptorManager);
+
+        httpAsyncConnector.timeout(streamData, resultFuture);
+
+        verify(errorReporter, times(1)).reportFatalException(any(TimeoutException.class));
+    }
+
+    @Test
+    public void shouldReportFatalInTimeoutIfFailOnErrorIsTrueWithFailOnErrorCodeRange() throws Exception {
+        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, "401-600", httpConfigType, "345", headers, outputMapping, "metricId_02", false);
         HttpAsyncConnector httpAsyncConnector = new HttpAsyncConnector(httpSourceConfig, externalMetricConfig, schemaConfig, httpClient, errorReporter, meterStatsManager, defaultDescriptorManager);
 
         httpAsyncConnector.timeout(streamData, resultFuture);
@@ -434,7 +454,7 @@ public class HttpAsyncConnectorTest {
 
     @Test
     public void shouldReportNonFatalInTimeoutIfFailOnErrorIsFalse() {
-        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", false, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
+        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", false, null, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
         HttpAsyncConnector httpAsyncConnector = new HttpAsyncConnector(httpSourceConfig, externalMetricConfig, schemaConfig, httpClient, errorReporter, meterStatsManager, defaultDescriptorManager);
 
         httpAsyncConnector.timeout(streamData, resultFuture);
@@ -454,7 +474,7 @@ public class HttpAsyncConnectorTest {
     public void shouldThrowExceptionIfUnsupportedHttpVerbProvided() throws Exception {
         when(defaultDescriptorManager.getDescriptor(inputProtoClasses[0])).thenReturn(TestBookingLogMessage.getDescriptor());
 
-        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "PATCH", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
+        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "PATCH", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, null, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
         HttpAsyncConnector httpAsyncConnector = new HttpAsyncConnector(httpSourceConfig, externalMetricConfig, schemaConfig, httpClient, errorReporter, meterStatsManager, defaultDescriptorManager);
 
         httpAsyncConnector.open(flinkConfiguration);

--- a/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/http/HttpAsyncConnectorTest.java
+++ b/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/http/HttpAsyncConnectorTest.java
@@ -139,21 +139,33 @@ public class HttpAsyncConnectorTest {
     @Test
     public void shouldReturnEmptySetIfFailOnErrorsExclusionCodeRangeNULL() throws Exception {
         HttpAsyncConnector httpAsyncConnector = new HttpAsyncConnector(defaultHttpSourceConfig, externalMetricConfig, schemaConfig, httpClient, errorReporter, meterStatsManager, defaultDescriptorManager);
-        Set<Integer> failOnErrorsExclusionSet = httpAsyncConnector.getFailOnErrorsExclusionSet(null);
+
+        httpAsyncConnector.open(flinkConfiguration);
+
+        Set<Integer> failOnErrorsExclusionSet = httpAsyncConnector.getFailOnErrorsExclusionSet();
         assertTrue(failOnErrorsExclusionSet.isEmpty());
     }
 
     @Test
     public void shouldReturnEmptySetIfFailOnErrorsExclusionCodeRangeEmpty() throws Exception {
         HttpAsyncConnector httpAsyncConnector = new HttpAsyncConnector(defaultHttpSourceConfig, externalMetricConfig, schemaConfig, httpClient, errorReporter, meterStatsManager, defaultDescriptorManager);
-        Set<Integer> failOnErrorsExclusionSet = httpAsyncConnector.getFailOnErrorsExclusionSet("");
+
+        httpAsyncConnector.open(flinkConfiguration);
+
+        Set<Integer> failOnErrorsExclusionSet = httpAsyncConnector.getFailOnErrorsExclusionSet();
         assertTrue(failOnErrorsExclusionSet.isEmpty());
     }
 
     @Test
     public void shouldReturnSetIfFailOnErrorsExclusionCodeRangeProvided() throws Exception {
+        defaultHttpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}",
+                "customer_id", "", "", "123", "234", true, "400,410-499", httpConfigType, "345",
+                headers, outputMapping, "metricId_02", false);
         HttpAsyncConnector httpAsyncConnector = new HttpAsyncConnector(defaultHttpSourceConfig, externalMetricConfig, schemaConfig, httpClient, errorReporter, meterStatsManager, defaultDescriptorManager);
-        Set<Integer> failOnErrorsExclusionSet = httpAsyncConnector.getFailOnErrorsExclusionSet("400,410-499");
+
+        httpAsyncConnector.open(flinkConfiguration);
+
+        Set<Integer> failOnErrorsExclusionSet = httpAsyncConnector.getFailOnErrorsExclusionSet();
         assertTrue(failOnErrorsExclusionSet.contains(400));
         assertFalse(failOnErrorsExclusionSet.contains(401));
         assertFalse(failOnErrorsExclusionSet.contains(409));

--- a/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/http/HttpResponseHandlerTest.java
+++ b/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/http/HttpResponseHandlerTest.java
@@ -20,10 +20,8 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
+import java.util.stream.IntStream;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -79,7 +77,7 @@ public class HttpResponseHandlerTest {
 
     @Test
     public void shouldPassInputIfFailOnErrorFalseAndStatusCodeIs404() {
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         when(response.getStatusCode()).thenReturn(404);
 
         httpResponseHandler.startTimer();
@@ -96,7 +94,7 @@ public class HttpResponseHandlerTest {
 
     @Test
     public void shouldPassInputIfFailOnErrorFalseAndStatusCodeIs4XXOtherThan404() {
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         when(response.getStatusCode()).thenReturn(402);
 
         httpResponseHandler.startTimer();
@@ -113,7 +111,7 @@ public class HttpResponseHandlerTest {
 
     @Test
     public void shouldPassInputIfFailOnErrorFalseAndStatusCodeIs5XX() {
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         when(response.getStatusCode()).thenReturn(502);
 
         httpResponseHandler.startTimer();
@@ -131,7 +129,7 @@ public class HttpResponseHandlerTest {
 
     @Test
     public void shouldPassInputIfFailOnErrorFalseAndStatusCodeIsOtherThan5XXAnd4XX() {
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         when(response.getStatusCode()).thenReturn(302);
 
         httpResponseHandler.startTimer();
@@ -149,7 +147,7 @@ public class HttpResponseHandlerTest {
     @Test
     public void shouldThrowErrorIfFailOnErrorTrueAndStatusCodeIs404() {
         httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, "", httpConfigType, "345", headers, outputMapping, "metricId_02", false);
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         when(response.getStatusCode()).thenReturn(404);
 
         httpResponseHandler.startTimer();
@@ -168,7 +166,7 @@ public class HttpResponseHandlerTest {
     @Test
     public void shouldThrowErrorIfFailOnErrorTrueAndStatusCodeIs4XXOtherThan404() {
         httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, "", httpConfigType, "345", headers, outputMapping, "metricId_02", false);
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         when(response.getStatusCode()).thenReturn(400);
 
         httpResponseHandler.startTimer();
@@ -186,7 +184,7 @@ public class HttpResponseHandlerTest {
     @Test
     public void shouldThrowErrorIfFailOnErrorTrueAndStatusCodeIs5XX() {
         httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, "", httpConfigType, "345", headers, outputMapping, "metricId_02", false);
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         when(response.getStatusCode()).thenReturn(502);
 
         httpResponseHandler.startTimer();
@@ -204,7 +202,7 @@ public class HttpResponseHandlerTest {
     @Test
     public void shouldThrowErrorIfFailOnErrorTrueAndStatusCodeIsOtherThan5XXAnd4XX() {
         httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, "", httpConfigType, "345", headers, outputMapping, "metricId_02", false);
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         when(response.getStatusCode()).thenReturn(302);
 
         httpResponseHandler.startTimer();
@@ -221,7 +219,7 @@ public class HttpResponseHandlerTest {
 
     @Test
     public void shouldPassInputIfFailOnErrorFalseAndOnThrowable() {
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         Throwable throwable = new Throwable("throwable message");
 
         httpResponseHandler.startTimer();
@@ -238,7 +236,7 @@ public class HttpResponseHandlerTest {
     @Test
     public void shouldThrowErrorIfFailOnErrorTrueAndOnThrowable() {
         httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, "", httpConfigType, "345", headers, outputMapping, "metricId_02", false);
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         Throwable throwable = new Throwable("throwable message");
 
         httpResponseHandler.startTimer();
@@ -256,7 +254,9 @@ public class HttpResponseHandlerTest {
     @Test
     public void shouldThrowErrorIfFailOnErrorTrueAndOnThrowableWithExcludeFailOnErrorsCodeRange() {
         httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, "404-499", httpConfigType, "345", headers, outputMapping, "metricId_02", false);
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HashSet<Integer> failOnErrorsExclusionSet = new HashSet<Integer>();
+        IntStream.rangeClosed(404, 499).forEach(statusCode -> failOnErrorsExclusionSet.add(statusCode));
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, failOnErrorsExclusionSet, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         Throwable throwable = new Throwable("throwable message");
 
         httpResponseHandler.startTimer();
@@ -274,7 +274,7 @@ public class HttpResponseHandlerTest {
     @Test
     public void shouldFailForAnyNone2xxIfFailOnErrorsTrueWithNullExcludeFailOnErrorsCodeRange() {
         httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, null, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         when(response.getStatusCode()).thenReturn(400);
 
         httpResponseHandler.startTimer();
@@ -292,7 +292,7 @@ public class HttpResponseHandlerTest {
     @Test
     public void shouldFailForAnyNone2xxIfFailOnErrorsTrueWithEmptyExcludeFailOnErrorsCodeRange() {
         httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, "", httpConfigType, "345", headers, outputMapping, "metricId_02", false);
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         when(response.getStatusCode()).thenReturn(400);
 
         httpResponseHandler.startTimer();
@@ -310,7 +310,10 @@ public class HttpResponseHandlerTest {
     @Test
     public void shouldPassForAnyNone2xxInsideOfFailOnErrorsCodeRangeIfFailOnErrorsTrue() {
         httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, "400,404-499", httpConfigType, "345", headers, outputMapping, "metricId_02", false);
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HashSet<Integer> failOnErrorsExclusionSet = new HashSet<Integer>();
+        IntStream.rangeClosed(404, 499).forEach(statusCode -> failOnErrorsExclusionSet.add(statusCode));
+        failOnErrorsExclusionSet.add(400);
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, failOnErrorsExclusionSet, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         when(response.getStatusCode()).thenReturn(400);
 
         httpResponseHandler.startTimer();
@@ -328,7 +331,10 @@ public class HttpResponseHandlerTest {
     @Test
     public void shouldFailForAnyNone2xxOutsideOfFailOnErrorsCodeRangeIfFailOnErrorsTrue() {
         httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, "400,404-499", httpConfigType, "345", headers, outputMapping, "metricId_02", false);
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HashSet<Integer> failOnErrorsExclusionSet = new HashSet<Integer>();
+        IntStream.rangeClosed(404, 499).forEach(statusCode -> failOnErrorsExclusionSet.add(statusCode));
+        failOnErrorsExclusionSet.add(400);
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, failOnErrorsExclusionSet, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         when(response.getStatusCode()).thenReturn(502);
 
         httpResponseHandler.startTimer();
@@ -349,7 +355,7 @@ public class HttpResponseHandlerTest {
         outputColumnNames = Collections.singletonList("surge_factor");
         columnNameManager = new ColumnNameManager(inputColumnNames, outputColumnNames);
         httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", false, "", httpConfigType, "345", headers, outputMapping, "metricId_02", false);
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         Row resultStreamData = new Row(2);
         Row outputData = new Row(2);
         outputData.setField(0, 0.732f);
@@ -375,7 +381,7 @@ public class HttpResponseHandlerTest {
         outputColumnNames = Arrays.asList("surge_factor", "s2_id_level");
         columnNameManager = new ColumnNameManager(inputColumnNames, outputColumnNames);
         httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", false, "", httpConfigType, "345", headers, outputMapping, "metricId_02", false);
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         Row resultStreamData = new Row(2);
         Row outputData = new Row(2);
         outputData.setField(0, 0.732f);
@@ -408,7 +414,7 @@ public class HttpResponseHandlerTest {
         when(response.getResponseBody()).thenReturn("{\n"
                 + "  \"surge\": 0.732\n"
                 + "}");
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
 
         httpResponseHandler.startTimer();
         assertThrows(NullPointerException.class,
@@ -422,7 +428,7 @@ public class HttpResponseHandlerTest {
         outputColumnNames = Collections.singletonList("surge_factor");
         columnNameManager = new ColumnNameManager(inputColumnNames, outputColumnNames);
         httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", true, "", httpConfigType, "345", headers, outputMapping, "metricId_02", false);
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         Row resultStreamData = new Row(2);
         Row outputData = new Row(2);
         outputData.setField(0, 0.732f);
@@ -447,7 +453,7 @@ public class HttpResponseHandlerTest {
         outputColumnNames = Collections.singletonList("surge_factor");
         columnNameManager = new ColumnNameManager(inputColumnNames, outputColumnNames);
         httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", false, "", null, "345", headers, outputMapping, "metricId_02", true);
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         Row resultStreamData = new Row(2);
         Row outputData = new Row(2);
         outputData.setField(0, 0.732);
@@ -472,7 +478,7 @@ public class HttpResponseHandlerTest {
         outputColumnNames = Collections.singletonList("surge_factor");
         columnNameManager = new ColumnNameManager(inputColumnNames, outputColumnNames);
         httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", false, null, null, "345", headers, outputMapping, "metricId_02", false);
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         Row resultStreamData = new Row(2);
         Row outputData = new Row(2);
         outputData.setField(0, 0.732f);
@@ -497,7 +503,7 @@ public class HttpResponseHandlerTest {
         outputColumnNames = Collections.singletonList("surge_factor");
         columnNameManager = new ColumnNameManager(inputColumnNames, outputColumnNames);
         httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "customer_id", "", "", "123", "234", false, null, httpConfigType, "345", headers, outputMapping, "metricId_02", false);
-        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
+        HttpResponseHandler httpResponseHandler = new HttpResponseHandler(httpSourceConfig, new HashSet<Integer>(), meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
         Row resultStreamData = new Row(2);
         Row outputData = new Row(2);
         outputData.setField(0, 0.732f);

--- a/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/http/HttpSourceConfigTest.java
+++ b/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/http/HttpSourceConfigTest.java
@@ -27,6 +27,7 @@ public class HttpSourceConfigTest {
     private String headerVariables;
     private String connectTimeout;
     private boolean failOnErrors;
+    private String failOnErrorsCodeRange;
     private String type;
     private String capacity;
     private String metricId;
@@ -49,11 +50,12 @@ public class HttpSourceConfigTest {
         headerVariables = "customer_id";
         connectTimeout = "234";
         failOnErrors = false;
+        failOnErrorsCodeRange = "";
         type = "InputProtoMessage";
         capacity = "345";
         metricId = "metricId-http-01";
         retainResponseType = false;
-        defaultHttpSourceConfig = new HttpSourceConfig(endpoint, endpointVariable, verb, requestPattern, requestVariables, headerPattern, headerVariables, streamTimeout, connectTimeout, failOnErrors, type, capacity, headerMap, outputMappings, metricId, retainResponseType);
+        defaultHttpSourceConfig = new HttpSourceConfig(endpoint, endpointVariable, verb, requestPattern, requestVariables, headerPattern, headerVariables, streamTimeout, connectTimeout, failOnErrors, failOnErrorsCodeRange, type, capacity, headerMap, outputMappings, metricId, retainResponseType);
     }
 
     @Test
@@ -113,13 +115,13 @@ public class HttpSourceConfigTest {
 
     @Test
     public void hasTypeShouldBeFalseWhenTypeIsNull() {
-        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("", "", "", "", "", "", "", null, "", false, null, "", new HashMap<>(), new HashMap<>(), metricId, false);
+        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("", "", "", "", "", "", "", null, "", false, null, null, "", new HashMap<>(), new HashMap<>(), metricId, false);
         assertFalse(httpSourceConfig.hasType());
     }
 
     @Test
     public void hasTypeShouldBeFalseWhenTypeIsEmpty() {
-        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("", "", "", "", "", "", "", "", "", false, "", "", new HashMap<>(), new HashMap<>(), metricId, false);
+        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("", "", "", "", "", "", "", "", "", false, null, "", "", new HashMap<>(), new HashMap<>(), metricId, false);
         assertFalse(httpSourceConfig.hasType());
     }
 
@@ -153,7 +155,7 @@ public class HttpSourceConfigTest {
     @Test
     public void shouldThrowExceptionIfAllFieldsMissing() {
 
-        HttpSourceConfig httpSourceConfig = new HttpSourceConfig(null, null, null, null, requestVariables, null, null, null, null, false, null, capacity, null, null, metricId, retainResponseType);
+        HttpSourceConfig httpSourceConfig = new HttpSourceConfig(null, null, null, null, requestVariables, null, null, null, null, false, null, null, capacity, null, null, metricId, retainResponseType);
         IllegalArgumentException exception =
                 assertThrows(IllegalArgumentException.class, () -> httpSourceConfig.validateFields());
         assertEquals("Missing required fields: [endpoint, streamTimeout, requestPattern, verb, connectTimeout, outputMapping]", exception.getMessage());
@@ -162,7 +164,7 @@ public class HttpSourceConfigTest {
     @Test
     public void shouldThrowExceptionIfSomeFieldsMissing() {
 
-        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("localhost", "", "post", "body", requestVariables, null, null, null, null, false, null, capacity, null, null, "metricId_01", retainResponseType);
+        HttpSourceConfig httpSourceConfig = new HttpSourceConfig("localhost", "", "post", "body", requestVariables, null, null, null, null, false, null, null, capacity, null, null, "metricId_01", retainResponseType);
         IllegalArgumentException exception =
                 assertThrows(IllegalArgumentException.class, () -> httpSourceConfig.validateFields());
         assertEquals("Missing required fields: [streamTimeout, connectTimeout, outputMapping]", exception.getMessage());
@@ -176,7 +178,7 @@ public class HttpSourceConfigTest {
         outputMappings.put("field", outputMappingWithNullField);
 
         defaultHttpSourceConfig = new HttpSourceConfig("http://localhost", "",
-                "post", "request_body", requestVariables, "", "", "4000", "1000", false, "", capacity, headerMap, outputMappings, "metricId_01", retainResponseType);
+                "post", "request_body", requestVariables, "", "", "4000", "1000", false, null, "", capacity, headerMap, outputMappings, "metricId_01", retainResponseType);
         IllegalArgumentException exception =
                 assertThrows(IllegalArgumentException.class, () -> defaultHttpSourceConfig.validateFields());
         assertEquals("Missing required fields: [path]", exception.getMessage());
@@ -191,7 +193,7 @@ public class HttpSourceConfigTest {
         outputMappings.put("field", outputMappingWithNullField);
 
         defaultHttpSourceConfig = new HttpSourceConfig("http://localhost", "",
-                "post", "", requestVariables, "", "", "4000", "1000", false, "", capacity, headerMap, outputMappings, "metricId_01", retainResponseType);
+                "post", "", requestVariables, "", "", "4000", "1000", false, null, "", capacity, headerMap, outputMappings, "metricId_01", retainResponseType);
         IllegalArgumentException exception =
                 assertThrows(IllegalArgumentException.class, () -> defaultHttpSourceConfig.validateFields());
         assertEquals("Missing required fields: [requestPattern]", exception.getMessage());
@@ -226,7 +228,7 @@ public class HttpSourceConfigTest {
     @Test
     public void shouldValidateWhenOutputMappingIsEmpty() {
 
-        defaultHttpSourceConfig = new HttpSourceConfig(endpoint, endpointVariable, verb, requestPattern, requestVariables, headerPattern, headerVariables, streamTimeout, connectTimeout, failOnErrors, type, capacity, headerMap, new HashMap<>(), "metricId_01", retainResponseType);
+        defaultHttpSourceConfig = new HttpSourceConfig(endpoint, endpointVariable, verb, requestPattern, requestVariables, headerPattern, headerVariables, streamTimeout, connectTimeout, failOnErrors, failOnErrorsCodeRange, type, capacity, headerMap, new HashMap<>(), "metricId_01", retainResponseType);
 
         IllegalArgumentException exception =
                 assertThrows(IllegalArgumentException.class, () -> defaultHttpSourceConfig.validateFields());

--- a/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/http/request/HttpGetRequestHandlerTest.java
+++ b/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/http/request/HttpGetRequestHandlerTest.java
@@ -40,14 +40,14 @@ public class HttpGetRequestHandlerTest {
 
     @Test
     public void shouldReturnTrueForGetVerbOnCanCreate() {
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "GET", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, "type", "345", new HashMap<>(), null, "metricId_01", false);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "GET", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, "", "type", "345", new HashMap<>(), null, "metricId_01", false);
         HttpGetRequestHandler httpGetRequestBuilder = new HttpGetRequestHandler(httpSourceConfig, httpClient, requestVariablesValues.toArray(), headerVariablesValues.toArray(), endpointVariablesValues.toArray());
         assertTrue(httpGetRequestBuilder.canCreate());
     }
 
     @Test
     public void shouldReturnFalseForVerbOtherThanGetOnCanBuild() {
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, "type", "345", new HashMap<>(), null, "metricId_01", false);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, "", "type", "345", new HashMap<>(), null, "metricId_01", false);
         HttpGetRequestHandler httpGetRequestBuilder = new HttpGetRequestHandler(httpSourceConfig, httpClient, requestVariablesValues.toArray(), headerVariablesValues.toArray(), endpointVariablesValues.toArray());
         assertFalse(httpGetRequestBuilder.canCreate());
     }
@@ -55,7 +55,7 @@ public class HttpGetRequestHandlerTest {
     @Test
     public void shouldBuildGetRequest() {
         when(httpClient.prepareGet("http://localhost:8080/test/key/1")).thenReturn(request);
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "GET", "/key/%s", "1", "", "", "123", "234", false, "type", "345", new HashMap<>(), null, "metricId_01", false);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "GET", "/key/%s", "1", "", "", "123", "234", false, "", "type", "345", new HashMap<>(), null, "metricId_01", false);
         HttpGetRequestHandler httpGetRequestBuilder = new HttpGetRequestHandler(httpSourceConfig, httpClient, requestVariablesValues.toArray(), headerVariablesValues.toArray(), endpointVariablesValues.toArray());
         assertEquals(request, httpGetRequestBuilder.create());
     }
@@ -64,7 +64,7 @@ public class HttpGetRequestHandlerTest {
     public void shouldBuildGetRequestWithOnlyDynamicHeader() {
         when(httpClient.prepareGet("http://localhost:8080/test/key/1")).thenReturn(request);
         when(request.addHeader("header_key", "1")).thenReturn(request);
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "GET", "/key/%s", "1", "{\"header_key\": \"%s\"}", "1", "123", "234", false, "type", "345", new HashMap<>(), null, "metricId_01", false);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "GET", "/key/%s", "1", "{\"header_key\": \"%s\"}", "1", "123", "234", false, "", "type", "345", new HashMap<>(), null, "metricId_01", false);
         HttpGetRequestHandler httpGetRequestBuilder = new HttpGetRequestHandler(httpSourceConfig, httpClient, requestVariablesValues.toArray(), headerVariablesValues.toArray(), endpointVariablesValues.toArray());
         httpGetRequestBuilder.create();
         verify(request, times(1)).addHeader(anyString(), anyString());
@@ -77,7 +77,7 @@ public class HttpGetRequestHandlerTest {
         when(request.addHeader("header_key", "1")).thenReturn(request);
         HashMap<String, String> staticHeader = new HashMap<String, String>();
         staticHeader.put("static", "2");
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "GET", "/key/%s", "1", "{\"header_key\": \"%s\"}", "1", "123", "234", false, "type", "345", staticHeader, null, "metricId_01", false);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "GET", "/key/%s", "1", "{\"header_key\": \"%s\"}", "1", "123", "234", false, "", "type", "345", staticHeader, null, "metricId_01", false);
         HttpGetRequestHandler httpGetRequestBuilder = new HttpGetRequestHandler(httpSourceConfig, httpClient, requestVariablesValues.toArray(), headerVariablesValues.toArray(), endpointVariablesValues.toArray());
         httpGetRequestBuilder.create();
         verify(request, times(2)).addHeader(anyString(), anyString());
@@ -90,7 +90,7 @@ public class HttpGetRequestHandlerTest {
         when(httpClient.prepareGet("http://localhost:8080/test/key/1")).thenReturn(request);
         HashMap<String, String> staticHeader = new HashMap<String, String>();
         staticHeader.put("static", "3");
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "GET", "/key/%s", "1", "{\"header_key_1\": \"%s\",\"header_key_2\": \"%s\"}", "1,2", "123", "234", false, "type", "345", staticHeader, null, "metricId_01", false);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "GET", "/key/%s", "1", "{\"header_key_1\": \"%s\",\"header_key_2\": \"%s\"}", "1,2", "123", "234", false, "", "type", "345", staticHeader, null, "metricId_01", false);
         HttpGetRequestHandler httpGetRequestBuilder = new HttpGetRequestHandler(httpSourceConfig, httpClient, requestVariablesValues.toArray(), headerVariablesValues.toArray(), endpointVariablesValues.toArray());
         httpGetRequestBuilder.create();
         verify(request, times(3)).addHeader(anyString(), anyString());
@@ -107,7 +107,7 @@ public class HttpGetRequestHandlerTest {
         ArrayList incompatibleHeaderVariablesValues = new ArrayList<>();
         incompatibleHeaderVariablesValues.add("test1");
         incompatibleHeaderVariablesValues.add("test12");
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "GET", "/key/%s", "1", "{\"header_key_1\": \"%s\",\"header_key_2\": \"%d\"}", "1,2", "123", "234", false, "type", "345", staticHeader, null, "metricId_01", false);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "GET", "/key/%s", "1", "{\"header_key_1\": \"%s\",\"header_key_2\": \"%d\"}", "1,2", "123", "234", false, "", "type", "345", staticHeader, null, "metricId_01", false);
         HttpGetRequestHandler httpGetRequestBuilder = new HttpGetRequestHandler(httpSourceConfig, httpClient, requestVariablesValues.toArray(), incompatibleHeaderVariablesValues.toArray(), endpointVariablesValues.toArray());
         InvalidConfigurationException exception = assertThrows(InvalidConfigurationException.class, () -> httpGetRequestBuilder.create());
         assertEquals("pattern config '{\"header_key_1\": \"%s\",\"header_key_2\": \"%d\"}' is incompatible with the variable config '1,2'", exception.getMessage());
@@ -118,7 +118,7 @@ public class HttpGetRequestHandlerTest {
         when(httpClient.prepareGet("http://localhost:8080/test/key/1")).thenReturn(request);
         HashMap<String, String> staticHeader = new HashMap<String, String>();
         staticHeader.put("static", "3");
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "GET", "/key/%s", "1", "{\"header_key_1\": \"%s\",\"header_key_2\": \"%p\"}", "1,2", "123", "234", false, "type", "345", staticHeader, null, "metricId_01", false);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "GET", "/key/%s", "1", "{\"header_key_1\": \"%s\",\"header_key_2\": \"%p\"}", "1,2", "123", "234", false, "", "type", "345", staticHeader, null, "metricId_01", false);
         HttpGetRequestHandler httpGetRequestBuilder = new HttpGetRequestHandler(httpSourceConfig, httpClient, requestVariablesValues.toArray(), headerVariablesValues.toArray(), endpointVariablesValues.toArray());
         InvalidConfigurationException exception = assertThrows(InvalidConfigurationException.class, () -> httpGetRequestBuilder.create());
         assertEquals("pattern config '{\"header_key_1\": \"%s\",\"header_key_2\": \"%p\"}' is invalid", exception.getMessage());

--- a/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/http/request/HttpPostRequestHandlerTest.java
+++ b/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/http/request/HttpPostRequestHandlerTest.java
@@ -41,14 +41,14 @@ public class HttpPostRequestHandlerTest {
 
     @Test
     public void shouldReturnTrueForPostVerbOnCanCreate() {
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", null, "POST", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, "type", "345", new HashMap<>(), null, "metricId_01", false);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", null, "POST", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, null, "type", "345", new HashMap<>(), null, "metricId_01", false);
         HttpPostRequestHandler httpPostRequestBuilder = new HttpPostRequestHandler(httpSourceConfig, httpClient, requestVariablesValues.toArray(), dynamicHeaderVariablesValues.toArray(), endpointVariablesValues.toArray());
         assertTrue(httpPostRequestBuilder.canCreate());
     }
 
     @Test
     public void shouldReturnFalseForVerbOtherThanPostOnCanBuild() {
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "GET", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, "type", "345", new HashMap<>(), null, "metricId_01", false);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "GET", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, null, "type", "345", new HashMap<>(), null, "metricId_01", false);
         HttpPostRequestHandler httpPostRequestBuilder = new HttpPostRequestHandler(httpSourceConfig, httpClient, requestVariablesValues.toArray(), dynamicHeaderVariablesValues.toArray(), endpointVariablesValues.toArray());
         assertFalse(httpPostRequestBuilder.canCreate());
     }
@@ -57,7 +57,7 @@ public class HttpPostRequestHandlerTest {
     public void shouldBuildPostRequestWithoutHeader() {
         when(httpClient.preparePost("http://localhost:8080/test")).thenReturn(request);
         when(request.setBody("{\"key\": \"1\"}")).thenReturn(request);
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, "type", "345", new HashMap<>(), null, "metricId_01", false);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, null, "type", "345", new HashMap<>(), null, "metricId_01", false);
         HttpPostRequestHandler httpPostRequestBuilder = new HttpPostRequestHandler(httpSourceConfig, httpClient, requestVariablesValues.toArray(), dynamicHeaderVariablesValues.toArray(), endpointVariablesValues.toArray());
         assertEquals(request, httpPostRequestBuilder.create());
     }
@@ -66,7 +66,7 @@ public class HttpPostRequestHandlerTest {
     public void shouldBuildPostRequestWithOnlyDynamicHeader() {
         when(httpClient.preparePost("http://localhost:8080/test")).thenReturn(request);
         when(request.setBody("{\"key\": \"1\"}")).thenReturn(request);
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "1", "{\"header_key\": \"%s\"}", "1", "123", "234", false, "type", "345", new HashMap<>(), null, "metricId_01", false);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "1", "{\"header_key\": \"%s\"}", "1", "123", "234", false, null, "type", "345", new HashMap<>(), null, "metricId_01", false);
         HttpPostRequestHandler httpPostRequestBuilder = new HttpPostRequestHandler(httpSourceConfig, httpClient, requestVariablesValues.toArray(), dynamicHeaderVariablesValues.toArray(), endpointVariablesValues.toArray());
         httpPostRequestBuilder.create();
         verify(request, times(1)).addHeader(anyString(), anyString());
@@ -79,7 +79,7 @@ public class HttpPostRequestHandlerTest {
         when(request.setBody("{\"key\": \"1\"}")).thenReturn(request);
         HashMap<String, String> staticHeader = new HashMap<String, String>();
         staticHeader.put("static", "2");
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "1", "{\"header_key\": \"%s\"}", "1", "123", "234", false, "type", "345", staticHeader, null, "metricId_01", false);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "1", "{\"header_key\": \"%s\"}", "1", "123", "234", false, null, "type", "345", staticHeader, null, "metricId_01", false);
         HttpPostRequestHandler httpPostRequestBuilder = new HttpPostRequestHandler(httpSourceConfig, httpClient, requestVariablesValues.toArray(), dynamicHeaderVariablesValues.toArray(), endpointVariablesValues.toArray());
         httpPostRequestBuilder.create();
         verify(request, times(2)).addHeader(anyString(), anyString());
@@ -93,7 +93,7 @@ public class HttpPostRequestHandlerTest {
         when(request.setBody("{\"key\": \"1\"}")).thenReturn(request);
         HashMap<String, String> staticHeader = new HashMap<String, String>();
         staticHeader.put("static", "3");
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "1", "{\"header_key_1\": \"%s\",\"header_key_2\": \"%s\"}", "1,2", "123", "234", false, "type", "345", staticHeader, null, "metricId_01", false);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "1", "{\"header_key_1\": \"%s\",\"header_key_2\": \"%s\"}", "1,2", "123", "234", false, null, "type", "345", staticHeader, null, "metricId_01", false);
         HttpPostRequestHandler httpPostRequestBuilder = new HttpPostRequestHandler(httpSourceConfig, httpClient, requestVariablesValues.toArray(), dynamicHeaderVariablesValues.toArray(), endpointVariablesValues.toArray());
         httpPostRequestBuilder.create();
         verify(request, times(3)).addHeader(anyString(), anyString());
@@ -111,7 +111,7 @@ public class HttpPostRequestHandlerTest {
         ArrayList incompatibleHeaderVariablesValues = new ArrayList<>();
         incompatibleHeaderVariablesValues.add("test1");
         incompatibleHeaderVariablesValues.add("test12");
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "1", "{\"header_key_1\": \"%s\",\"header_key_2\": \"%d\"}", "1,2", "123", "234", false, "type", "345", staticHeader, null, "metricId_01", false);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "1", "{\"header_key_1\": \"%s\",\"header_key_2\": \"%d\"}", "1,2", "123", "234", false, null, "type", "345", staticHeader, null, "metricId_01", false);
         HttpPostRequestHandler httpPostRequestBuilder = new HttpPostRequestHandler(httpSourceConfig, httpClient, requestVariablesValues.toArray(), incompatibleHeaderVariablesValues.toArray(), endpointVariablesValues.toArray());
         InvalidConfigurationException exception = assertThrows(InvalidConfigurationException.class, () -> httpPostRequestBuilder.create());
         assertEquals("pattern config '{\"header_key_1\": \"%s\",\"header_key_2\": \"%d\"}' is incompatible with the variable config '1,2'", exception.getMessage());
@@ -123,7 +123,7 @@ public class HttpPostRequestHandlerTest {
         when(request.setBody("{\"key\": \"1\"}")).thenReturn(request);
         HashMap<String, String> staticHeader = new HashMap<String, String>();
         staticHeader.put("static", "3");
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "1", "{\"header_key_1\": \"%s\",\"header_key_2\": \"%p\"}", "1,2", "123", "234", false, "type", "345", staticHeader, null, "metricId_01", false);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "POST", "{\"key\": \"%s\"}", "1", "{\"header_key_1\": \"%s\",\"header_key_2\": \"%p\"}", "1,2", "123", "234", false, null, "type", "345", staticHeader, null, "metricId_01", false);
         HttpPostRequestHandler httpPostRequestBuilder = new HttpPostRequestHandler(httpSourceConfig, httpClient, requestVariablesValues.toArray(), dynamicHeaderVariablesValues.toArray(), endpointVariablesValues.toArray());
         InvalidConfigurationException exception = assertThrows(InvalidConfigurationException.class, () -> httpPostRequestBuilder.create());
         assertEquals("pattern config '{\"header_key_1\": \"%s\",\"header_key_2\": \"%p\"}' is invalid", exception.getMessage());

--- a/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/http/request/HttpRequestFactoryTest.java
+++ b/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/http/request/HttpRequestFactoryTest.java
@@ -41,7 +41,7 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void shouldReturnPostRequestOnTheBasisOfConfiguration() {
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", null, "POST", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, "type", "345", new HashMap<>(), null, "metricId_01", retainResponseType);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", null, "POST", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, null, "type", "345", new HashMap<>(), null, "metricId_01", retainResponseType);
         when(httpClient.preparePost("http://localhost:8080/test")).thenReturn(request);
         when(request.setBody("{\"key\": \"123456\"}")).thenReturn(request);
         HttpRequestFactory.createRequest(httpSourceConfig, httpClient, requestVariablesValues.toArray(), headerVariablesValues.toArray(), endpointVariablesValues.toArray());
@@ -53,7 +53,7 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void shouldReturnPostRequestWithMultiEndpointVariablesOnTheBasisOfConfiguration() {
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test/%s/%s", "exp, 222", "POST", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, "type", "345", new HashMap<>(), null, "metricId_01", retainResponseType);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test/%s/%s", "exp, 222", "POST", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, null, "type", "345", new HashMap<>(), null, "metricId_01", retainResponseType);
         when(httpClient.preparePost("http://localhost:8080/test/exp/222")).thenReturn(request);
         when(request.setBody("{\"key\": \"123456\"}")).thenReturn(request);
         endpointVariablesValues.add("exp");
@@ -67,7 +67,7 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void shouldReturnGetRequestOnTheBasisOfConfiguration() {
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", null, "GET", "/key/%s", "1", "", "", "123", "234", false, "type", "345", new HashMap<>(), null, "metricId_01", retainResponseType);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", null, "GET", "/key/%s", "1", "", "", "123", "234", false, null, "type", "345", new HashMap<>(), null, "metricId_01", retainResponseType);
         when(httpClient.prepareGet("http://localhost:8080/test/key/1")).thenReturn(request);
         HttpRequestFactory.createRequest(httpSourceConfig, httpClient, requestVariablesValues.toArray(), headerVariablesValues.toArray(), endpointVariablesValues.toArray());
 
@@ -78,7 +78,7 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void shouldReturnGetRequestWithMultiEndpointVariablesOnTheBasisOfConfiguration() {
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test/%s/%s", "123, 332", "GET", "/key/%s", "1", "", "", "123", "234", false, "type", "345", new HashMap<>(), null, "metricId_01", retainResponseType);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test/%s/%s", "123, 332", "GET", "/key/%s", "1", "", "", "123", "234", false, null, "type", "345", new HashMap<>(), null, "metricId_01", retainResponseType);
         when(httpClient.prepareGet("http://localhost:8080/test/key/1")).thenReturn(request);
         endpointVariablesValues.add("123");
         endpointVariablesValues.add("332");
@@ -90,7 +90,7 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void shouldReturnPutRequestOnTheBasisOfConfiguration() {
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test/%s", "123", "PUT", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, "type", "345", new HashMap<>(), null, "metricId_01", retainResponseType);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test/%s", "123", "PUT", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, null, "type", "345", new HashMap<>(), null, "metricId_01", retainResponseType);
         when(httpClient.preparePut("http://localhost:8080/test/123")).thenReturn(request);
         when(request.setBody("{\"key\": \"123456\"}")).thenReturn(request);
         endpointVariablesValues.add("123");
@@ -103,7 +103,7 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void shouldReturnPutRequestWithMultiEndpointVariablesOnTheBasisOfConfiguration() {
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test/%s/abc/%s", "123, 321, asd", "PUT", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, "type", "345", new HashMap<>(), null, "metricId_01", retainResponseType);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test/%s/abc/%s", "123, 321, asd", "PUT", "{\"key\": \"%s\"}", "1", "", "", "123", "234", false, null, "type", "345", new HashMap<>(), null, "metricId_01", retainResponseType);
         when(httpClient.preparePut("http://localhost:8080/test/123/abc/asd")).thenReturn(request);
         when(request.setBody("{\"key\": \"123456\"}")).thenReturn(request);
         endpointVariablesValues.add("123");
@@ -118,7 +118,7 @@ public class HttpRequestFactoryTest {
 
     @Test
     public void shouldThrowExceptionForUnsupportedHttpVerb() {
-        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "PATCH", "/key/%s", "1", "", "", "123", "234", false, "type", "345", new HashMap<>(), null, "metricId_01", retainResponseType);
+        httpSourceConfig = new HttpSourceConfig("http://localhost:8080/test", "", "PATCH", "/key/%s", "1", "", "", "123", "234", false, null, "type", "345", new HashMap<>(), null, "metricId_01", retainResponseType);
         assertThrows(InvalidHttpVerbException.class, () -> HttpRequestFactory.createRequest(httpSourceConfig, httpClient, requestVariablesValues.toArray(), headerVariablesValues.toArray(), endpointVariablesValues.toArray()));
     }
 

--- a/docs/docs/advance/post_processor.md
+++ b/docs/docs/advance/post_processor.md
@@ -291,6 +291,13 @@ A flag for deciding whether the job should fail on encountering errors(timeout a
 - Type: `optional`
 - Default value: `false`
 
+##### `exclude_fail_on_errors_code_range`
+
+Defines the exclusion range of HTTP status codes for which job should not fail if `fail_on_errors` is true.
+
+- Example value: `400,404-499`
+- Type: `optional`
+
 ##### `capacity`
 
 This parameter(Async I/O capacity) defines how many max asynchronous requests may be in progress at the same time.


### PR DESCRIPTION
feat: Added exclusion range with fail_on_errors for HTTP post-processors
GTF side we have some use cases where we must ignore some of the HTTP response codes when fail_on_errors is true. 