### PR TITLE
chore: Map external_source response to the nested output proto field

### DIFF
--- a/dagger-core/src/main/java/com/gotocompany/dagger/core/processors/external/grpc/GrpcResponseHandler.java
+++ b/dagger-core/src/main/java/com/gotocompany/dagger/core/processors/external/grpc/GrpcResponseHandler.java
@@ -14,6 +14,7 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
+import com.gotocompany.dagger.core.utils.DescriptorsUtil;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import io.grpc.stub.StreamObserver;
@@ -111,10 +112,14 @@ public class GrpcResponseHandler implements StreamObserver<DynamicMessage> {
     }
 
     private void setFieldUsingType(String key, Object value, int fieldIndex) {
-        Descriptors.FieldDescriptor fieldDescriptor = descriptor.findFieldByName(key);
-        if (fieldDescriptor == null) {
-            IllegalArgumentException illegalArgumentException = new IllegalArgumentException("Field Descriptor not found for field: " + key);
-            reportAndThrowError(illegalArgumentException);
+        Descriptors.FieldDescriptor fieldDescriptor = null;
+        try {
+            fieldDescriptor = DescriptorsUtil.getFieldDescriptor(descriptor, key);
+            if (fieldDescriptor == null) {
+                throw new IllegalArgumentException("Field Descriptor not found for field: " + key);
+            }
+        } catch (RuntimeException exception) {
+            reportAndThrowError(exception);
         }
         TypeHandler typeHandler = TypeHandlerFactory.getTypeHandler(fieldDescriptor);
         rowManager.setInOutput(fieldIndex, typeHandler.transformFromPostProcessor(value));

--- a/dagger-core/src/main/java/com/gotocompany/dagger/core/utils/DescriptorsUtil.java
+++ b/dagger-core/src/main/java/com/gotocompany/dagger/core/utils/DescriptorsUtil.java
@@ -1,22 +1,31 @@
 package com.gotocompany.dagger.core.utils;
 
 import com.google.protobuf.Descriptors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+
+import static com.google.protobuf.Descriptors.FieldDescriptor.JavaType.MESSAGE;
 
 /**
  * Utility class that contains helper methods to get {@link Descriptors} {@link  Descriptors.FieldDescriptor}.
  */
 public class DescriptorsUtil {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(DescriptorsUtil.class.getName());
+
     /**
      * Gets FieldDescriptor .
      *
      * @param descriptor the descriptor
-     * @param columnName  the columnName
+     * @param columnName the columnName
      * @return the fieldDescriptor
      */
     public static Descriptors.FieldDescriptor getFieldDescriptor(Descriptors.Descriptor descriptor, String columnName) {
+        if (descriptor == null || columnName == null) {
+            return null;
+        }
         String[] nestedFields = columnName.split("\\.");
         if (nestedFields.length == 1) {
             return descriptor.findFieldByName(columnName);
@@ -28,18 +37,22 @@ public class DescriptorsUtil {
     /**
      * Gets FieldDescriptor .
      *
-     * @param parentDescriptor the descriptor
+     * @param parentDescriptor  the descriptor
      * @param nestedColumnNames the array of columnNames
      * @return the fieldDescriptor
      */
     public static Descriptors.FieldDescriptor getNestedFieldDescriptor(Descriptors.Descriptor parentDescriptor, String[] nestedColumnNames) {
+        if (parentDescriptor == null || nestedColumnNames == null || nestedColumnNames.length == 0) {
+            return null;
+        }
         String childColumnName = nestedColumnNames[0];
         if (nestedColumnNames.length == 1) {
             return parentDescriptor.findFieldByName(childColumnName);
         }
         Descriptors.FieldDescriptor childFieldDescriptor = parentDescriptor.findFieldByName(childColumnName);
-        if (childFieldDescriptor == null) {
-            throw new IllegalArgumentException(String.format("Field Descriptor not found for field: %s in the proto of %s", childColumnName, parentDescriptor.getFullName()));
+        if (childFieldDescriptor == null || childFieldDescriptor.getJavaType() != MESSAGE) {
+            LOGGER.info(String.format("Either the Field Descriptor for the field '%s' is missing in the proto '%s', or the Field Descriptor is not of the MESSAGE type.", childColumnName, parentDescriptor.getFullName()));
+            return null;
         }
         Descriptors.Descriptor childDescriptor = childFieldDescriptor.getMessageType();
         return getNestedFieldDescriptor(childDescriptor, Arrays.copyOfRange(nestedColumnNames, 1, nestedColumnNames.length));

--- a/dagger-core/src/main/java/com/gotocompany/dagger/core/utils/DescriptorsUtil.java
+++ b/dagger-core/src/main/java/com/gotocompany/dagger/core/utils/DescriptorsUtil.java
@@ -1,0 +1,47 @@
+package com.gotocompany.dagger.core.utils;
+
+import com.google.protobuf.Descriptors;
+
+import java.util.Arrays;
+
+/**
+ * Utility class that contains helper methods to get {@link Descriptors} {@link  Descriptors.FieldDescriptor}.
+ */
+public class DescriptorsUtil {
+
+    /**
+     * Gets FieldDescriptor .
+     *
+     * @param descriptor the descriptor
+     * @param columnName  the columnName
+     * @return the fieldDescriptor
+     */
+    public static Descriptors.FieldDescriptor getFieldDescriptor(Descriptors.Descriptor descriptor, String columnName) {
+        String[] nestedFields = columnName.split("\\.");
+        if (nestedFields.length == 1) {
+            return descriptor.findFieldByName(columnName);
+        } else {
+            return getNestedFieldDescriptor(descriptor, nestedFields);
+        }
+    }
+
+    /**
+     * Gets FieldDescriptor .
+     *
+     * @param parentDescriptor the descriptor
+     * @param nestedColumnNames the array of columnNames
+     * @return the fieldDescriptor
+     */
+    public static Descriptors.FieldDescriptor getNestedFieldDescriptor(Descriptors.Descriptor parentDescriptor, String[] nestedColumnNames) {
+        String childColumnName = nestedColumnNames[0];
+        if (nestedColumnNames.length == 1) {
+            return parentDescriptor.findFieldByName(childColumnName);
+        }
+        Descriptors.FieldDescriptor childFieldDescriptor = parentDescriptor.findFieldByName(childColumnName);
+        if (childFieldDescriptor == null) {
+            throw new IllegalArgumentException(String.format("Field Descriptor not found for field: %s in the proto of %s", childColumnName, parentDescriptor.getFullName()));
+        }
+        Descriptors.Descriptor childDescriptor = childFieldDescriptor.getMessageType();
+        return getNestedFieldDescriptor(childDescriptor, Arrays.copyOfRange(nestedColumnNames, 1, nestedColumnNames.length));
+    }
+}

--- a/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/grpc/GrpcResponseHandlerTest.java
+++ b/dagger-core/src/test/java/com/gotocompany/dagger/core/processors/external/grpc/GrpcResponseHandlerTest.java
@@ -405,39 +405,4 @@ public class GrpcResponseHandlerTest {
         verify(resultFuture, times(1)).completeExceptionally(exceptionCaptor2.capture());
         assertEquals("Field Descriptor not found for field: driver_pickup_location.invalid_address", exceptionCaptor2.getValue().getMessage());
     }
-    @Test
-    public void shouldThrowErrorWhenNestedParentFieldIsNotPresentInOutputDescriptor() throws InvalidProtocolBufferException {
-        descriptor = TestBookingLogMessage.getDescriptor();
-        outputMapping.put("driver-pickup-location.address", new OutputMapping("$.driver_pickup_location.address"));
-        TestLocation location = TestLocation.newBuilder().setAddress("Indonesia").setName("GojekTech").build();
-        TestBookingLogMessage bookingLogMessage = TestBookingLogMessage.newBuilder().setDriverPickupLocation(location).setCustomerId("123456").build();
-
-        grpcSourceConfig = new GrpcSourceConfigBuilder().setEndpoint("localhost").setServicePort(8000).setGrpcRequestProtoSchema("com.gotocompany.dagger.consumer.TestGrpcRequest").setGrpcResponseProtoSchema("com.gotocompany.dagger.consumer.TestGrpcResponse").setGrpcMethodUrl("com.gotocompany.dagger.consumer.test/TestMethod").setRequestPattern("{\"key\": \"%s\"}").setRequestVariables("customer_id").setOutputMapping(outputMapping).createGrpcSourceConfig();
-        grpcSourceConfig.setRetainResponseType(false);
-
-        outputColumnNames = Arrays.asList("driver-pickup-location.address");
-        columnNameManager = new ColumnNameManager(inputColumnNames, outputColumnNames);
-
-        DynamicMessage message = DynamicMessage.parseFrom(TestBookingLogMessage.getDescriptor(), bookingLogMessage.toByteArray());
-        GrpcResponseHandler grpcResponseHandler = new GrpcResponseHandler(grpcSourceConfig, meterStatsManager, rowManager, columnNameManager, descriptor, resultFuture, errorReporter, new PostResponseTelemetry());
-
-        Row resultStreamData = new Row(2);
-        Row outputData = new Row(2);
-        outputData.setField(0, "Indonesia");
-        outputData.setField(1, "GojekTech");
-        resultStreamData.setField(0, inputData);
-        resultStreamData.setField(1, outputData);
-
-        grpcResponseHandler.startTimer();
-        assertThrows(Exception.class, () -> grpcResponseHandler.onNext(message));
-
-        ArgumentCaptor<IllegalArgumentException> exceptionCaptor = ArgumentCaptor.forClass(IllegalArgumentException.class);
-        verify(errorReporter, times(1)).reportFatalException(exceptionCaptor.capture());
-        assertEquals("Field Descriptor not found for field: driver-pickup-location in the proto of com.gotocompany.dagger.consumer.TestBookingLogMessage", exceptionCaptor.getValue().getMessage());
-
-        ArgumentCaptor<IllegalArgumentException> exceptionCaptor2 = ArgumentCaptor.forClass(IllegalArgumentException.class);
-        verify(resultFuture, times(1)).completeExceptionally(exceptionCaptor2.capture());
-        assertEquals("Field Descriptor not found for field: driver-pickup-location in the proto of com.gotocompany.dagger.consumer.TestBookingLogMessage", exceptionCaptor2.getValue().getMessage());
-    }
-
 }

--- a/dagger-core/src/test/java/com/gotocompany/dagger/core/utils/DescriptorsUtilTest.java
+++ b/dagger-core/src/test/java/com/gotocompany/dagger/core/utils/DescriptorsUtilTest.java
@@ -6,7 +6,6 @@ import com.gotocompany.dagger.consumer.TestEnrichedBookingLogMessage;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -40,6 +39,24 @@ public class DescriptorsUtilTest {
     }
 
     @Test
+    public void shouldGiveNullForEmptyFieldFieldDescriptor() {
+        String nonExistentField = "customer-id";
+        Descriptors.FieldDescriptor nonExistentFieldDescriptor = DescriptorsUtil.getFieldDescriptor(null, nonExistentField);
+        assertNull(nonExistentFieldDescriptor);
+    }
+    @Test
+    public void shouldGiveNullForNullColumnFieldFieldDescriptor() {
+        Descriptors.Descriptor descriptor = TestCustomerLogMessage.getDescriptor();
+        Descriptors.FieldDescriptor nonExistentFieldDescriptor = DescriptorsUtil.getFieldDescriptor(descriptor, null);
+        assertNull(nonExistentFieldDescriptor);
+    }
+    @Test
+    public void shouldGiveNullForEmptyColumnFieldFieldDescriptor() {
+        Descriptors.Descriptor descriptor = TestCustomerLogMessage.getDescriptor();
+        Descriptors.FieldDescriptor nonExistentFieldDescriptor = DescriptorsUtil.getFieldDescriptor(descriptor, "");
+        assertNull(nonExistentFieldDescriptor);
+    }
+    @Test
     public void shouldGiveNullForInvalidFieldFieldDescriptor() {
         Descriptors.Descriptor descriptor = TestCustomerLogMessage.getDescriptor();
         String nonExistentField = "customer-id";
@@ -55,8 +72,9 @@ public class DescriptorsUtilTest {
         assertNull(invalidFieldDescriptor);
     }
 
+
     @Test
-    public void shouldGiveNullForInvlidNestedFieldColumnsDescriptor() {
+    public void shouldGiveNullForInvalidNestedFieldColumnsDescriptor() {
         Descriptors.Descriptor parentDescriptor = TestEnrichedBookingLogMessage.getDescriptor();
         String[] invalidNestedFieldNames = {"customer_profile", "customer-id"};
         Descriptors.FieldDescriptor invalidFieldDescriptor = DescriptorsUtil.getNestedFieldDescriptor(parentDescriptor, invalidNestedFieldNames);
@@ -64,21 +82,22 @@ public class DescriptorsUtilTest {
     }
 
     @Test
-    public void shouldThrowExceptionWhenNestedColumnDoesNotExists() {
-        Descriptors.Descriptor parentDescriptor = TestEnrichedBookingLogMessage.getDescriptor();
-        String invalidNestedFieldNames = "booking_log.driver_pickup-location.name";
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                () -> DescriptorsUtil.getFieldDescriptor(parentDescriptor, invalidNestedFieldNames));
-        assertEquals("Field Descriptor not found for field: driver_pickup-location in the proto of com.gotocompany.dagger.consumer.TestBookingLogMessage",
-                exception.getMessage());
+    public void shouldGiveNullForNullNestedFieldDescriptor() {
+        String[] nonExistentField = new String[]{"customer-id"};
+        Descriptors.FieldDescriptor nonExistentFieldDescriptor = DescriptorsUtil.getNestedFieldDescriptor(null, nonExistentField);
+        assertNull(nonExistentFieldDescriptor);
+    }
+
+    @Test
+    public void shouldGiveNullForNullColumnNestedFieldDescriptor() {
+        Descriptors.Descriptor descriptor = TestCustomerLogMessage.getDescriptor();
+        Descriptors.FieldDescriptor nonExistentFieldDescriptor = DescriptorsUtil.getNestedFieldDescriptor(descriptor, null);
+        assertNull(nonExistentFieldDescriptor);
     }
     @Test
-    public void shouldThrowExceptionWhenNestedColumnGetFieldDescriptorDoesNotExists() {
-        Descriptors.Descriptor parentDescriptor = TestEnrichedBookingLogMessage.getDescriptor();
-        String[] invalidNestedFieldNames = {"booking_log", "driver_pickup-location", "name"};
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                () -> DescriptorsUtil.getNestedFieldDescriptor(parentDescriptor, invalidNestedFieldNames));
-        assertEquals("Field Descriptor not found for field: driver_pickup-location in the proto of com.gotocompany.dagger.consumer.TestBookingLogMessage",
-                exception.getMessage());
+    public void shouldGiveNullForEmptyColumnNestedFieldDescriptor() {
+        Descriptors.Descriptor descriptor = TestCustomerLogMessage.getDescriptor();
+        Descriptors.FieldDescriptor nonExistentFieldDescriptor = DescriptorsUtil.getNestedFieldDescriptor(descriptor, new String[]{});
+        assertNull(nonExistentFieldDescriptor);
     }
 }

--- a/dagger-core/src/test/java/com/gotocompany/dagger/core/utils/DescriptorsUtilTest.java
+++ b/dagger-core/src/test/java/com/gotocompany/dagger/core/utils/DescriptorsUtilTest.java
@@ -1,0 +1,84 @@
+package com.gotocompany.dagger.core.utils;
+
+import com.google.protobuf.Descriptors;
+import com.gotocompany.dagger.consumer.TestCustomerLogMessage;
+import com.gotocompany.dagger.consumer.TestEnrichedBookingLogMessage;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class DescriptorsUtilTest {
+
+    @Test
+    public void shouldGetFieldDescriptor() {
+        String fieldName = "customer_id";
+        Descriptors.Descriptor descriptor = TestCustomerLogMessage.getDescriptor();
+        Descriptors.FieldDescriptor fieldDescriptor = DescriptorsUtil.getFieldDescriptor(descriptor, fieldName);
+        assertNotNull(fieldDescriptor);
+        assertEquals("customer_id", fieldDescriptor.getName());
+    }
+
+    @Test
+    public void shouldRunGetNestedFieldDescriptor() {
+        String fieldName = "customer_profile.customer_id";
+        Descriptors.Descriptor descriptor = TestEnrichedBookingLogMessage.getDescriptor();
+        Descriptors.FieldDescriptor fieldDescriptor = DescriptorsUtil.getFieldDescriptor(descriptor, fieldName);
+        assertNotNull(fieldDescriptor);
+        assertEquals("customer_id", fieldDescriptor.getName());
+    }
+
+    @Test
+    public void shouldRunGetNestedFieldColumnsDescriptor() {
+        Descriptors.Descriptor parentDescriptor = TestEnrichedBookingLogMessage.getDescriptor();
+        String[] nestedFieldNames = {"customer_profile", "customer_id"};
+        Descriptors.FieldDescriptor fieldDescriptor = DescriptorsUtil.getNestedFieldDescriptor(parentDescriptor, nestedFieldNames);
+        assertNotNull(fieldDescriptor);
+        assertEquals("customer_id", fieldDescriptor.getName());
+    }
+
+    @Test
+    public void shouldGiveNullForInvalidFieldFieldDescriptor() {
+        Descriptors.Descriptor descriptor = TestCustomerLogMessage.getDescriptor();
+        String nonExistentField = "customer-id";
+        Descriptors.FieldDescriptor nonExistentFieldDescriptor = DescriptorsUtil.getFieldDescriptor(descriptor, nonExistentField);
+        assertNull(nonExistentFieldDescriptor);
+    }
+
+    @Test
+    public void shouldGiveNullForInvalidNestedFieldDescriptor() {
+        Descriptors.Descriptor parentDescriptor = TestEnrichedBookingLogMessage.getDescriptor();
+        String fieldName = "customer_profile.customer-id";
+        Descriptors.FieldDescriptor invalidFieldDescriptor = DescriptorsUtil.getFieldDescriptor(parentDescriptor, fieldName);
+        assertNull(invalidFieldDescriptor);
+    }
+
+    @Test
+    public void shouldGiveNullForInvlidNestedFieldColumnsDescriptor() {
+        Descriptors.Descriptor parentDescriptor = TestEnrichedBookingLogMessage.getDescriptor();
+        String[] invalidNestedFieldNames = {"customer_profile", "customer-id"};
+        Descriptors.FieldDescriptor invalidFieldDescriptor = DescriptorsUtil.getNestedFieldDescriptor(parentDescriptor, invalidNestedFieldNames);
+        assertNull(invalidFieldDescriptor);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenNestedColumnDoesNotExists() {
+        Descriptors.Descriptor parentDescriptor = TestEnrichedBookingLogMessage.getDescriptor();
+        String invalidNestedFieldNames = "booking_log.driver_pickup-location.name";
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> DescriptorsUtil.getFieldDescriptor(parentDescriptor, invalidNestedFieldNames));
+        assertEquals("Field Descriptor not found for field: driver_pickup-location in the proto of com.gotocompany.dagger.consumer.TestBookingLogMessage",
+                exception.getMessage());
+    }
+    @Test
+    public void shouldThrowExceptionWhenNestedColumnGetFieldDescriptorDoesNotExists() {
+        Descriptors.Descriptor parentDescriptor = TestEnrichedBookingLogMessage.getDescriptor();
+        String[] invalidNestedFieldNames = {"booking_log", "driver_pickup-location", "name"};
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> DescriptorsUtil.getNestedFieldDescriptor(parentDescriptor, invalidNestedFieldNames));
+        assertEquals("Field Descriptor not found for field: driver_pickup-location in the proto of com.gotocompany.dagger.consumer.TestBookingLogMessage",
+                exception.getMessage());
+    }
+}


### PR DESCRIPTION
Within the context of the dagger post-processor, when enhancing data through an external API, the response is presently linked to an extra field within the output-proto. However, if the intention is to associate it with an existing nested field instead, the current approach falls short. This adjustment aims to enable the mapping of this response to the pre-existing nested field within the output proto. By doing so, the need for introducing the additional field will be avoided, resulting in a more efficient proto schema mapping for the output proto.

e.g
Mapping of external API response to the nested existing field `driver-pickup-location.address `in the output proto [here](https://github.com/goto/dagger/blob/11fc8e1b9f01466901c4d29312b98e6dcfbc52d4/dagger-common/src/test/proto/TestLogMessage.proto#L64)
By this way we can avoid introducing new field address in the output proto.

```
"output_mapping": {
    "driver-pickup-location.address": {
	    "path": "$.driver_pickup_location.address"
    }
}
```